### PR TITLE
Remove the `util` variable as it is not used

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,5 +1,4 @@
 
-var util = require('util')
 var assert = require('assert')
 var values = require('./values')
 


### PR DESCRIPTION
A small fix to cleanup the code based on `standard` report.