### PR TITLE
Create `build` workflow to test the library on NodeJS 12, 14 and 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: build
+
+on:
+  push:
+  pull_request:
+    branches:
+    - master
+    - main
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-13 ]
+        node: [ 12, 14, 16 ]
+
+    runs-on: ${{ matrix.os }}
+
+    name: build node v${{ matrix.node }} ${{ matrix.os }}
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: setup node ${{ matrix.node }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node }}
+
+    - name: setup python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10' 
+
+    - name: npm install
+      run: npm install
+
+    - name: npm tests
+      run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,18 @@ jobs:
     - name: setup python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10' 
+        python-version: '3.10'
+
+    - name: prepare test volume
+      run: |
+        hdiutil create macos_alias_volume_hfs.dmg -ov -size 32m -fs HFS+ -volname "macos_alias"
+        hdiutil attach macos_alias_volume_hfs.dmg
+        cp test/basics.js /Volumes/macos_alias
 
     - name: npm install
       run: npm install
 
     - name: npm tests
       run: npm test
+      env:
+        ROOT_VOLUME: '/Volumes/macos_alias'

--- a/test/basics.js
+++ b/test/basics.js
@@ -58,7 +58,8 @@ describe('encode', function () {
 
 describe('create', function () {
   it('should create a simple alias', function () {
-    var buf = lib.create(path.join(__dirname, 'basics.js'))
+    var rootDir = process.env['ROOT_VOLUME'] || __dirname
+    var buf = lib.create(path.join(rootDir, 'basics.js'))
     var info = lib.decode(buf)
 
     assert.equal('file', info.target.type)


### PR DESCRIPTION
The workflow runs on macOS 13 using NodeJS 12, 14 and 16.

This tests the package on older NodeJS runtimes to ensure it works and it can be compiled as it has some native code.