### PR TITLE
Rebrand the library as `@appdmg/macos-alias`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-alias
+# @appdmg/node-alias
 
 Mac OS aliases creation and reading from node.js
 
@@ -11,13 +11,13 @@ I intend to add something like `alias.write(buf, path)` and `alias.read(path)`.
 ## Installation
 
 ```sh
-npm install macos-alias
+npm install @appdmg/macos-alias
 ```
 
 ## Usage
 
 ```javascript
-var alias = require('macos-alias');
+var alias = require('@appdmg/macos-alias');
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "macos-alias",
+  "name": "@appdmg/macos-alias",
   "version": "0.2.12",
   "main": "index.js",
   "license": "MIT",
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/LinusU/node-alias.git"
+    "url": "https://github.com/appdmg/macos-alias.git"
   },
   "dependencies": {
     "nan": "^2.4.0"


### PR DESCRIPTION
Rebrand to library under the `@appdmg` org.

Package: https://www.npmjs.com/package/@appdmg/macos-alias