### PR TITLE
Add support for Linux platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13 ]
+        os: [ macos-13, ubuntu-latest ]
         node: [ 10, 12, 14, 16, 18, 20, 22 ]
 
     runs-on: ${{ matrix.os }}
@@ -34,10 +34,13 @@ jobs:
         python-version: '3.10'
 
     - name: prepare test volume
+      if: contains(matrix.os, 'macos')
+      id: test_volume
       run: |
         hdiutil create macos_alias_volume_hfs.dmg -ov -size 32m -fs HFS+ -volname "macos_alias"
         hdiutil attach macos_alias_volume_hfs.dmg
         cp test/basics.js /Volumes/macos_alias
+        echo "path=/Volumes/macos_alias" > "$GITHUB_OUTPUT"
 
     - name: npm ci
       run: npm ci
@@ -45,4 +48,4 @@ jobs:
     - name: npm tests
       run: npm test
       env:
-        ROOT_VOLUME: '/Volumes/macos_alias'
+        ROOT_VOLUME: ${{ steps.test_volume.outputs.path }}

--- a/lib/create.js
+++ b/lib/create.js
@@ -39,7 +39,7 @@ var utf16be = function (str) {
   return b
 }
 
-module.exports = exports = function (targetPath) {
+module.exports = exports = function (targetPath, options) {
   var info = { version: 2, extra: [] }
 
   var parentPath = path.resolve(targetPath, '..')
@@ -49,6 +49,8 @@ module.exports = exports = function (targetPath) {
   var volumeStat = fs.statSync(volumePath)
 
   assert(targetStat.isFile() || targetStat.isDirectory(), 'Target is a file or directory')
+
+  var volumneName = addon.getVolumeName(volumePath) || options.volumeName
 
   info.target = {
     id: targetStat.ino,
@@ -63,7 +65,7 @@ module.exports = exports = function (targetPath) {
   }
 
   info.volume = {
-    name: addon.getVolumeName(volumePath),
+    name: volumneName,
     created: volumeStat.ctime,
     signature: 'H+',
     type: (volumePath === '/' ? 'local' : 'other')

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@appdmg/macos-alias",
       "version": "0.2.13",
       "license": "MIT",
-      "os": [
-        "darwin"
-      ],
       "dependencies": {
         "nan": "^2.4.0"
       },
@@ -18,6 +15,10 @@
         "fs-temp": "^1.1.1",
         "mocha": "^3.1.0",
         "standard": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=7"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "Davide Liessi <davide.liessi@gmail.com>",
     "Joshua Warner <joshuawarner32@gmail.com>"
   ],
-  "os": [
-    "darwin"
-  ],
   "devDependencies": {
     "fs-temp": "^1.1.1",
     "mocha": "^3.1.0",

--- a/src/volume.cc
+++ b/src/volume.cc
@@ -8,7 +8,7 @@
 #else
 
 NAN_METHOD(MethodGetVolumeName) {
-  info.GetReturnValue().Set(Nan::New("Macintosh HD").ToLocalChecked());
+  info.GetReturnValue().SetNull();
 }
 
 #endif

--- a/src/volume.cc
+++ b/src/volume.cc
@@ -6,7 +6,11 @@
 #ifdef __APPLE__
 #include "impl-apple.cc"
 #else
-#error This platform is not implemented yet
+
+NAN_METHOD(MethodGetVolumeName) {
+  info.GetReturnValue().Set(Nan::New("Macintosh HD").ToLocalChecked());
+}
+
 #endif
 
 using v8::FunctionTemplate;

--- a/test/addon.js
+++ b/test/addon.js
@@ -3,8 +3,26 @@
 var assert = require('assert')
 var addon = require('../build/Release/volume.node')
 
-describe('addon', function () {
+describe('addon on macOS', function () {
+  before(function () {
+    if (process.platform !== 'darwin') {
+      this.skip()
+    }
+  })
+
   it('should find the volume name of /', function () {
     assert.equal(addon.getVolumeName('/'), 'Macintosh HD')
+  })
+})
+
+describe('addon on Linux', function () {
+  before(function () {
+    if (process.platform === 'darwin') {
+      this.skip()
+    }
+  })
+
+  it('getVolumeName() native functions return null', function () {
+    assert.equal(addon.getVolumeName('/'), null)
   })
 })

--- a/test/basics.js
+++ b/test/basics.js
@@ -59,7 +59,8 @@ describe('encode', function () {
 describe('create', function () {
   it('should create a simple alias', function () {
     var rootDir = process.env['ROOT_VOLUME'] || __dirname
-    var buf = lib.create(path.join(rootDir, 'basics.js'))
+    var volumeName = process.platform === 'darwin' ? undefined : 'Test Volume'
+    var buf = lib.create(path.join(rootDir, 'basics.js'), { volumeName })
     var info = lib.decode(buf)
 
     assert.equal('file', info.target.type)


### PR DESCRIPTION
The Alias file can be generated on Linux and Windows. The macOS specific `getVolumeName()` method will return `null` on other platforms and users can set the volume name explicitly in the `create()` function.

```js
const create = require('@appdmg/macos-alias')

const options = { volumeName: 'Virtual Disk' }
const buffer = create('file.txt', options)
```

Implements #8 