### PR TITLE
Update to `nan` v2.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,21 @@ jobs:
       matrix:
         os: [ macos-13, ubuntu-latest ]
         node: [ 10, 12, 14, 16, 18, 20, 22 ]
+        include:
+        - node: 10
+          python: '3.10'
+        - node: 12
+          python: '3.10'
+        - node: 14
+          python: '3.10'
+        - node: 16
+          python: '3.10'
+        - node: 18
+          python: '3.12'
+        - node: 20
+          python: '3.12'
+        - node: 22
+          python: '3.13'
 
     runs-on: ${{ matrix.os }}
 
@@ -28,10 +43,10 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
-    - name: setup python 3.10
+    - name: setup python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python }}
 
     - name: prepare test volume
       if: contains(matrix.os, 'macos')

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ I intend to add something like `alias.write(buf, path)` and `alias.read(path)`.
 
 To install and run the `macos-alias` package you need:
 
-* Mac OS X 10.11 or newer 
+* Mac OS X 10.11 or newer
 * macOS 11 or newer
 * NodeJS 10 or newer
-* Python 3.10
+* Python 3.10 or newer
+
+> [!NOTE]  
+> Building for NodeJS 10 - 16 requires Python 3.10.  
+> Building for NodeJS 18 and newer supports using latest Python releases.
 
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.4.0"
+        "nan": "^2.22.0"
       },
       "devDependencies": {
         "fs-temp": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/appdmg/macos-alias.git"
   },
   "dependencies": {
-    "nan": "^2.4.0"
+    "nan": "^2.22.0"
   },
   "engines": {
     "node": ">=10",

--- a/src/volume.cc
+++ b/src/volume.cc
@@ -20,4 +20,4 @@ NAN_MODULE_INIT(Initialize) {
     Nan::GetFunction(Nan::New<FunctionTemplate>(MethodGetVolumeName)).ToLocalChecked());
 }
 
-NODE_MODULE(volume, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)


### PR DESCRIPTION
The `nan` package v2.22 updates supported NodeJS runtimes to v22.

It also allows to use Python 3.12 and newer to build the C source code in the library.

> [!NOTE]  
> Building for NodeJS 10 - 16 still requires Python 3.10.
