### PR TITLE
Normalize large alias file IDs

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const assert = require('assert')
 const encode = require('./encode')
+const normalizeFileId = require('./file-id')
 
 const addon = require('../build/Release/volume.node')
 
@@ -65,14 +66,14 @@ module.exports = exports = function (targetPath, options) {
   const volumneName = addon.getVolumeName(volumePath) || options.volumeName
 
   info.target = {
-    id: targetStat.ino,
+    id: normalizeFileId(targetStat.ino),
     type: (targetStat.isDirectory() ? 'directory' : 'file'),
     filename: path.basename(targetPath),
     created: targetStat.ctime
   }
 
   info.parent = {
-    id: parentStat.ino,
+    id: normalizeFileId(parentStat.ino),
     name: path.basename(parentPath)
   }
 
@@ -96,7 +97,7 @@ module.exports = exports = function (targetPath, options) {
   (function addType1 () {
     const b = Buffer.alloc(4)
 
-    b.writeUInt32BE(info.parent.id, 0)
+    b.writeUInt32BE(normalizeFileId(info.parent.id), 0)
 
     info.extra.push({
       type: 1,

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const values = require('./values')
+const normalizeFileId = require('./file-id')
 
 const appleEpoch = Date.UTC(1904, 0, 1)
 const appleDate = function (value) {
@@ -57,7 +58,7 @@ module.exports = exports = function (info) {
   assert(volType >= 0 && volType <= 5, 'Volume type is valid')
   buf.writeUInt16BE(volType, 44)
 
-  buf.writeUInt32BE(info.parent.id, 46)
+  buf.writeUInt32BE(normalizeFileId(info.parent.id), 46)
 
   const fileNameLength = info.target.filename.length
   assert(fileNameLength <= 63, 'File name is not longer than 63 chars')
@@ -65,7 +66,7 @@ module.exports = exports = function (info) {
   buf.fill(0, 51, 51 + 63)
   buf.write(info.target.filename, 51, 'utf8')
 
-  buf.writeUInt32BE(info.target.id, 114)
+  buf.writeUInt32BE(normalizeFileId(info.target.id), 114)
 
   const fileCreateDate = appleDate(info.target.created)
   buf.writeUInt32BE(fileCreateDate, 118)

--- a/lib/file-id.js
+++ b/lib/file-id.js
@@ -1,0 +1,10 @@
+const UINT32_SIZE = 0x100000000
+const UINT32_MAX = UINT32_SIZE - 1
+
+module.exports = exports = function normalizeFileId (value) {
+  if (Number.isInteger(value) && value > UINT32_MAX) {
+    return value % UINT32_SIZE
+  }
+
+  return value
+}

--- a/test/basics.js
+++ b/test/basics.js
@@ -6,6 +6,8 @@ const path = require('node:path')
 const test = require('ava').default
 const alias = require('../')
 
+const UINT32_SIZE = 0x100000000
+
 const rawData = Buffer.from(
   'AAAAAAEqAAIAAApUZXN0IFRpdGxlAAAAAAAAAAAAAAAAAAAAAADO615USCsA' +
   'BQAAABMMVGVzdEJrZy50aWZmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
@@ -51,6 +53,21 @@ test('encode creates byte-identical alias data', (t) => {
   t.deepEqual(buf, rawData)
 })
 
+test('encode normalizes large file IDs to alias UInt32 fields', (t) => {
+  const info = alias.decode(rawData)
+  const parentId = 8_589_934_599
+  const targetId = 12_888_353_118
+
+  info.parent.id = parentId
+  info.target.id = targetId
+  info.extra = info.extra.filter((part) => part.type !== 1)
+
+  const buf = alias.encode(info)
+
+  t.is(buf.readUInt32BE(46), parentId % UINT32_SIZE)
+  t.is(buf.readUInt32BE(114), targetId % UINT32_SIZE)
+})
+
 test('create builds an alias for a file', (t) => {
   const rootDir = process.env.ROOT_VOLUME || __dirname
   const volumeName = process.platform === 'darwin' ? undefined : 'Test Volume'
@@ -60,6 +77,61 @@ test('create builds an alias for a file', (t) => {
 
   t.is(info.target.type, 'file')
   t.is(info.target.filename, 'basics.js')
+})
+
+test('create normalizes large file IDs to alias UInt32 fields', (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'macos-alias-large-id-'))
+  const target = path.join(tmpDir, 'target.txt')
+  fs.writeFileSync(target, 'target')
+
+  const originalStatSync = fs.statSync
+  const parentOfTmpDir = path.resolve(tmpDir, '..')
+  const targetIno = 12_888_353_118
+  const parentIno = 8_589_934_599
+
+  const createStat = function (ino, type) {
+    return {
+      dev: 1,
+      ino,
+      ctime: new Date('2026-01-02T03:04:05.000Z'),
+      isFile: () => type === 'file',
+      isDirectory: () => type === 'directory'
+    }
+  }
+
+  const targetStat = createStat(targetIno, 'file')
+  const parentStat = createStat(parentIno, 'directory')
+
+  fs.statSync = function (currentPath) {
+    const resolvedPath = path.resolve(currentPath)
+
+    if (resolvedPath === target) {
+      return targetStat
+    }
+
+    if (resolvedPath === tmpDir || resolvedPath === parentOfTmpDir) {
+      return parentStat
+    }
+
+    return originalStatSync.apply(this, arguments)
+  }
+
+  try {
+    const buf = alias.create(target, { volumeName: 'Test Volume' })
+    const info = alias.decode(buf)
+
+    const expectedParentId = parentIno % UINT32_SIZE
+    const expectedTargetId = targetIno % UINT32_SIZE
+    const parentIdExtra = info.extra.find((part) => part.type === 1)
+
+    t.is(info.parent.id, expectedParentId)
+    t.is(info.target.id, expectedTargetId)
+    t.truthy(parentIdExtra)
+    t.is(parentIdExtra.data.readUInt32BE(0), expectedParentId)
+  } finally {
+    fs.statSync = originalStatSync
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
 })
 
 test('isAlias identifies alias files', (t) => {


### PR DESCRIPTION
## Summary

Normalize macOS alias file IDs before writing them into the 32-bit fields used by the alias binary format.

## Root Cause

APFS inode/file IDs on GitHub macOS runners can exceed `uint32`. `create()` copied `fs.statSync(...).ino` directly into the alias info object, then wrote the parent ID into the type-1 extra record with `Buffer.writeUInt32BE()`. The same IDs are also written by `encode()` into the base parent and target ID fields. When a runner returned an inode such as `12888353118`, Node raised `ERR_OUT_OF_RANGE` before the alias could be encoded.

## Fix

Added a small file-ID normalizer that keeps valid UInt32 values unchanged and reduces larger positive integer IDs modulo `2^32`, matching the storage width of the alias format. `create()` uses it for target IDs, parent IDs, and the type-1 parent-ID extra record; `encode()` uses it for the base parent and target ID fields.

## Validation

- `npm ci`
- `npm test`
- `npm audit --audit-level=moderate`
- `npm ls --omit=dev --all`
- `npm pack --dry-run`
- `node --check index.js lib/create.js lib/encode.js lib/file-id.js lib/decode.js lib/is-alias.js lib/values.js test/basics.js test/addon.js`

Beads: `dmg-rtf`