### PR TITLE
Address publish workflow review feedback

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   publish:
     name: publish to npmjs
+    if: github.event.release.prerelease == false
     runs-on: macos-15-intel
 
     steps:
@@ -63,7 +64,22 @@ jobs:
     - name: verify runtime dependency tree
       run: npm ls --omit=dev --all
 
+    - name: check npm package version
+      id: npm_version
+      run: |
+        package_name="$(node -p "require('./package.json').name")"
+        package_version="$(node -p "require('./package.json').version")"
+
+        if npm view "${package_name}@${package_version}" version --json >/dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "package=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
+
     - name: pack package
+      if: steps.npm_version.outputs.exists == 'false'
       id: pack
       run: |
         mkdir -p dist
@@ -73,11 +89,13 @@ jobs:
         echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
     - name: attest npm package artifact
+      if: steps.npm_version.outputs.exists == 'false'
       uses: actions/attest@v4
       with:
         subject-path: ${{ steps.pack.outputs.tarball }}
 
     - name: upload npm package artifact
+      if: steps.npm_version.outputs.exists == 'false'
       uses: actions/upload-artifact@v4
       with:
         name: npm-package
@@ -85,6 +103,7 @@ jobs:
         if-no-files-found: error
 
     - name: publish package
+      if: steps.npm_version.outputs.exists == 'false'
       run: npm publish "$TARBALL" --provenance --access public
       env:
         TARBALL: ${{ steps.pack.outputs.tarball }}


### PR DESCRIPTION
## Summary
- skip npm publishing for GitHub prereleases so prerelease releases cannot publish the default latest dist-tag
- check whether the exact package version already exists on npm
- skip pack, attestation, artifact upload, and publish steps when the version is already published so workflow reruns are safe

## Verification
- YAML parse for publish workflow