### PR TITLE
Simplify npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,41 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  check:
+    name: check npm package version
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.npm_version.outputs.should_publish }}
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+
+    - name: setup node 24
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        registry-url: https://registry.npmjs.org
+
+    - name: check npm package version
+      id: npm_version
+      run: |
+        package_name="$(node -p "require('./package.json').name")"
+        package_version="$(node -p "require('./package.json').version")"
+
+        if npm view "${package_name}@${package_version}" version --json >/dev/null 2>&1; then
+          echo "${package_name}@${package_version} is already published; exiting without publishing."
+          echo "should_publish=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "${package_name}@${package_version} is not published yet; continuing."
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+        fi
+
   publish:
     name: publish to npmjs
-    if: github.event.release.prerelease == false
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
     runs-on: macos-15-intel
 
     steps:
@@ -31,12 +63,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.13'
-
-    - name: verify publish toolchain
-      run: |
-        node --version
-        npm --version
-        node -e "const version = require('node:child_process').execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(); const [major, minor, patch] = version.split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) throw new Error('npm 11.5.1 or newer is required for trusted publishing')"
 
     - name: prepare test volume
       id: test_volume
@@ -64,22 +90,7 @@ jobs:
     - name: verify runtime dependency tree
       run: npm ls --omit=dev --all
 
-    - name: check npm package version
-      id: npm_version
-      run: |
-        package_name="$(node -p "require('./package.json').name")"
-        package_version="$(node -p "require('./package.json').version")"
-
-        if npm view "${package_name}@${package_version}" version --json >/dev/null 2>&1; then
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-        fi
-
-        echo "package=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
-
     - name: pack package
-      if: steps.npm_version.outputs.exists == 'false'
       id: pack
       run: |
         mkdir -p dist
@@ -89,13 +100,11 @@ jobs:
         echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
     - name: attest npm package artifact
-      if: steps.npm_version.outputs.exists == 'false'
       uses: actions/attest@v4
       with:
         subject-path: ${{ steps.pack.outputs.tarball }}
 
     - name: upload npm package artifact
-      if: steps.npm_version.outputs.exists == 'false'
       uses: actions/upload-artifact@v4
       with:
         name: npm-package
@@ -103,7 +112,6 @@ jobs:
         if-no-files-found: error
 
     - name: publish package
-      if: steps.npm_version.outputs.exists == 'false'
       run: npm publish "$TARBALL" --provenance --access public
       env:
         TARBALL: ${{ steps.pack.outputs.tarball }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     outputs:
-      should_publish: ${{ steps.npm_version.outputs.should_publish }}
+      should_publish: ${{ steps.publish_status.outputs.exists == '0' }}
 
     steps:
     - name: checkout
@@ -29,21 +29,25 @@ jobs:
         registry-url: https://registry.npmjs.org
 
     - name: check npm package version
-      id: npm_version
+      id: publish_status
+      uses: tehpsalmist/npm-publish-status-action@01cb25946b194a7a5468f22c8e74db04c283f121
+
+    - name: report npm package version status
       run: |
         package_name="$(node -p "require('./package.json').name")"
         package_version="$(node -p "require('./package.json').version")"
 
-        if npm view "${package_name}@${package_version}" version --json >/dev/null 2>&1; then
+        if [ "${{ steps.publish_status.outputs.exists }}" = "1" ]; then
           echo "${package_name}@${package_version} is already published; exiting without publishing."
-          echo "should_publish=false" >> "$GITHUB_OUTPUT"
-        else
+        elif [ "${{ steps.publish_status.outputs.exists }}" = "0" ]; then
           echo "${package_name}@${package_version} is not published yet; continuing."
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::Unexpected npm publish status: ${{ steps.publish_status.outputs.exists }}"
+          exit 1
         fi
 
-  publish:
-    name: publish to npmjs
+  verify:
+    name: verify package
     needs: check
     if: needs.check.outputs.should_publish == 'true'
     runs-on: macos-15-intel
@@ -89,6 +93,59 @@ jobs:
 
     - name: verify runtime dependency tree
       run: npm ls --omit=dev --all
+
+  prepublish_check:
+    name: check npm package version before publish
+    needs: verify
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.publish_status.outputs.exists == '0' }}
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+
+    - name: setup node 24
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        registry-url: https://registry.npmjs.org
+
+    - name: check npm package version
+      id: publish_status
+      uses: tehpsalmist/npm-publish-status-action@01cb25946b194a7a5468f22c8e74db04c283f121
+
+    - name: report npm package version status
+      run: |
+        package_name="$(node -p "require('./package.json').name")"
+        package_version="$(node -p "require('./package.json').version")"
+
+        if [ "${{ steps.publish_status.outputs.exists }}" = "1" ]; then
+          echo "${package_name}@${package_version} was published while this workflow was verifying; exiting without publishing."
+        elif [ "${{ steps.publish_status.outputs.exists }}" = "0" ]; then
+          echo "${package_name}@${package_version} is still not published; continuing."
+        else
+          echo "::error::Unexpected npm publish status: ${{ steps.publish_status.outputs.exists }}"
+          exit 1
+        fi
+
+  publish:
+    name: publish to npmjs
+    needs: prepublish_check
+    if: needs.prepublish_check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+
+    - name: setup node 24
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        registry-url: https://registry.npmjs.org
+        cache: npm
 
     - name: pack package
       id: pack

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,25 +32,11 @@ jobs:
       id: publish_status
       uses: tehpsalmist/npm-publish-status-action@01cb25946b194a7a5468f22c8e74db04c283f121
 
-    - name: report npm package version status
-      run: |
-        package_name="$(node -p "require('./package.json').name")"
-        package_version="$(node -p "require('./package.json').version")"
-
-        if [ "${{ steps.publish_status.outputs.exists }}" = "1" ]; then
-          echo "${package_name}@${package_version} is already published; exiting without publishing."
-        elif [ "${{ steps.publish_status.outputs.exists }}" = "0" ]; then
-          echo "${package_name}@${package_version} is not published yet; continuing."
-        else
-          echo "::error::Unexpected npm publish status: ${{ steps.publish_status.outputs.exists }}"
-          exit 1
-        fi
-
-  verify:
-    name: verify package
+  publish:
+    name: publish to npmjs
     needs: check
     if: needs.check.outputs.should_publish == 'true'
-    runs-on: macos-15-intel
+    runs-on: ubuntu-latest
 
     steps:
     - name: checkout
@@ -62,90 +48,9 @@ jobs:
         node-version: 24
         registry-url: https://registry.npmjs.org
         cache: npm
-
-    - name: setup python 3.13
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-
-    - name: prepare test volume
-      id: test_volume
-      run: |
-        hdiutil create macos_alias_volume_hfs.dmg -ov -size 32m -fs HFS+ -volname "macos_alias"
-        hdiutil attach macos_alias_volume_hfs.dmg
-        cp test/basics.js /Volumes/macos_alias
-        echo "path=/Volumes/macos_alias" > "$GITHUB_OUTPUT"
 
     - name: npm ci
       run: npm ci
-
-    - name: npm test
-      run: npm test
-      env:
-        ROOT_VOLUME: ${{ steps.test_volume.outputs.path }}
-
-    - name: cleanup test volume
-      if: always()
-      run: hdiutil detach /Volumes/macos_alias || true
-
-    - name: audit dependencies
-      run: npm audit --audit-level=moderate
-
-    - name: verify runtime dependency tree
-      run: npm ls --omit=dev --all
-
-  prepublish_check:
-    name: check npm package version before publish
-    needs: verify
-    if: github.event.release.prerelease == false
-    runs-on: ubuntu-latest
-    outputs:
-      should_publish: ${{ steps.publish_status.outputs.exists == '0' }}
-
-    steps:
-    - name: checkout
-      uses: actions/checkout@v6
-
-    - name: setup node 24
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        registry-url: https://registry.npmjs.org
-
-    - name: check npm package version
-      id: publish_status
-      uses: tehpsalmist/npm-publish-status-action@01cb25946b194a7a5468f22c8e74db04c283f121
-
-    - name: report npm package version status
-      run: |
-        package_name="$(node -p "require('./package.json').name")"
-        package_version="$(node -p "require('./package.json').version")"
-
-        if [ "${{ steps.publish_status.outputs.exists }}" = "1" ]; then
-          echo "${package_name}@${package_version} was published while this workflow was verifying; exiting without publishing."
-        elif [ "${{ steps.publish_status.outputs.exists }}" = "0" ]; then
-          echo "${package_name}@${package_version} is still not published; continuing."
-        else
-          echo "::error::Unexpected npm publish status: ${{ steps.publish_status.outputs.exists }}"
-          exit 1
-        fi
-
-  publish:
-    name: publish to npmjs
-    needs: prepublish_check
-    if: needs.prepublish_check.outputs.should_publish == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: checkout
-      uses: actions/checkout@v6
-
-    - name: setup node 24
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        registry-url: https://registry.npmjs.org
-        cache: npm
 
     - name: pack package
       id: pack
@@ -160,13 +65,6 @@ jobs:
       uses: actions/attest@v4
       with:
         subject-path: ${{ steps.pack.outputs.tarball }}
-
-    - name: upload npm package artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: npm-package
-        path: ${{ steps.pack.outputs.tarball }}
-        if-no-files-found: error
 
     - name: publish package
       run: npm publish "$TARBALL" --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   publish:
     name: publish to npmjs
+    if: github.event.release.prerelease == false
     runs-on: macos-15-intel
 
     steps:
@@ -63,7 +64,22 @@ jobs:
     - name: verify runtime dependency tree
       run: npm ls --omit=dev --all
 
+    - name: check npm package version
+      id: npm_version
+      run: |
+        package_name="$(node -p "require('./package.json').name")"
+        package_version="$(node -p "require('./package.json').version")"
+
+        if npm view "${package_name}@${package_version}" version --json >/dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "package=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
+
     - name: pack package
+      if: steps.npm_version.outputs.exists == 'false'
       id: pack
       run: |
         mkdir -p dist
@@ -73,11 +89,13 @@ jobs:
         echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
     - name: attest npm package artifact
+      if: steps.npm_version.outputs.exists == 'false'
       uses: actions/attest@v4
       with:
         subject-path: ${{ steps.pack.outputs.tarball }}
 
     - name: upload npm package artifact
+      if: steps.npm_version.outputs.exists == 'false'
       uses: actions/upload-artifact@v4
       with:
         name: npm-package
@@ -85,6 +103,7 @@ jobs:
         if-no-files-found: error
 
     - name: publish package
+      if: steps.npm_version.outputs.exists == 'false'
       run: npm publish "$TARBALL" --provenance --access public
       env:
         TARBALL: ${{ steps.pack.outputs.tarball }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,37 +7,85 @@ on:
 permissions:
   contents: read
   id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish:
-    runs-on: macos-13
-
-    environment:
-      name: production
-      url: https://www.npmjs.com/package/@appdmg/macos-alias
+    name: publish to npmjs
+    runs-on: macos-15-intel
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
-    - name: setup node 20
-      uses: actions/setup-node@v4
+    - name: setup node 24
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
-        registry-url: ${{ vars.NODE_REGISTRY_URL }}
+        node-version: 24
+        registry-url: https://registry.npmjs.org
+        cache: npm
 
-    - name: setup python 3.10
-      uses: actions/setup-python@v5
+    - name: setup python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.13'
 
-    - name: setup npm
-      run: npm install -g npm@11
+    - name: verify publish toolchain
+      run: |
+        node --version
+        npm --version
+        node -e "const version = require('node:child_process').execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(); const [major, minor, patch] = version.split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) throw new Error('npm 11.5.1 or newer is required for trusted publishing')"
+
+    - name: prepare test volume
+      id: test_volume
+      run: |
+        hdiutil create macos_alias_volume_hfs.dmg -ov -size 32m -fs HFS+ -volname "macos_alias"
+        hdiutil attach macos_alias_volume_hfs.dmg
+        cp test/basics.js /Volumes/macos_alias
+        echo "path=/Volumes/macos_alias" > "$GITHUB_OUTPUT"
 
     - name: npm ci
       run: npm ci
 
-    - name: npm publish
-      run: npm publish --provenance --access public
+    - name: npm test
+      run: npm test
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NODE_REGISTRY_TOKEN }}
+        ROOT_VOLUME: ${{ steps.test_volume.outputs.path }}
+
+    - name: cleanup test volume
+      if: always()
+      run: hdiutil detach /Volumes/macos_alias || true
+
+    - name: audit dependencies
+      run: npm audit --audit-level=moderate
+
+    - name: verify runtime dependency tree
+      run: npm ls --omit=dev --all
+
+    - name: pack package
+      id: pack
+      run: |
+        mkdir -p dist
+        npm pack --json --pack-destination dist > dist/pack.json
+        tarball="$(find dist -maxdepth 1 -name '*.tgz' -print -quit)"
+        test -n "$tarball"
+        echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
+    - name: attest npm package artifact
+      uses: actions/attest@v4
+      with:
+        subject-path: ${{ steps.pack.outputs.tarball }}
+
+    - name: upload npm package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: npm-package
+        path: ${{ steps.pack.outputs.tarball }}
+        if-no-files-found: error
+
+    - name: publish package
+      run: npm publish "$TARBALL" --provenance --access public
+      env:
+        TARBALL: ${{ steps.pack.outputs.tarball }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Check the exact npm package version with `tehpsalmist/npm-publish-status-action` pinned to `01cb25946b194a7a5468f22c8e74db04c283f121`.
- Start the publish job only when that action reports `exists == 0`.
- Keep the publish path small: `npm ci`, `npm pack`, GitHub artifact attestation, and `npm publish --provenance`.

## Validation

- Parsed `.github/workflows/publish.yml` with Ruby YAML.
- Ran `actionlint v1.7.12`.
- Ran `git diff --check`.

Leaving this PR open for maintainer review.